### PR TITLE
converted bytes to string in json.loads

### DIFF
--- a/mentalcalculation.py
+++ b/mentalcalculation.py
@@ -295,7 +295,7 @@ class Main(QtWidgets.QMainWindow):
                 url = 'https://www.sorobanexam.org/mentalcalculation/ping?uuid=%s&version=%s' % (self.uuid, appVersion)
                 ret = urllib.request.urlopen(url)
                 if ret.getcode() == 200:
-                    latest_version = json.loads(ret.read())['latest']
+                    latest_version = json.loads(ret.read().decode('utf-8'))['latest']
                     if latest_version > appVersion:
                         self.ui.statusbar.showMessage('A new version is available at www.sorobanexam.org/anzan.html')
                 # stop tracking if url returns 404


### PR DESCRIPTION
This will prevent the following error
```console
[tarptaeya:mental_calculation]$ ./mentalcalculation.py 
Traceback (most recent call last):
  File "./mentalcalculation.py", line 762, in <module>
    f = Main()
  File "./mentalcalculation.py", line 221, in __init__
    self.importSettings()
  File "./mentalcalculation.py", line 298, in importSettings
    latest_version = json.loads(ret.read())['latest']
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'

```